### PR TITLE
Keep insertion order when deduplicate support urls

### DIFF
--- a/UniversalDownloaderPlatform.Engine/PluginManager.cs
+++ b/UniversalDownloaderPlatform.Engine/PluginManager.cs
@@ -109,7 +109,8 @@ namespace UniversalDownloaderPlatform.Engine
             if(string.IsNullOrWhiteSpace(htmlContents))
                 return new List<string>();
 
-            HashSet<string> retHashSet = new HashSet<string>();
+            HashSet<string> dedupeHashSet = new HashSet<string>();
+            List<string> retList = new List<string>(); 
             if (_plugins != null && _plugins.Count > 0)
             {
                 foreach (IPlugin plugin in _plugins)
@@ -118,7 +119,8 @@ namespace UniversalDownloaderPlatform.Engine
                     if (pluginRetList != null && pluginRetList.Count > 0)
                     {
                         foreach(string url in pluginRetList)
-                            retHashSet.Add(url);
+                            if(dedupeHashSet.Add(url))
+                                retList.Add(url);
                     }
                 }
             }
@@ -128,12 +130,12 @@ namespace UniversalDownloaderPlatform.Engine
             {
                 foreach (string url in defaultPluginRetList)
                 {
-                    if(!retHashSet.Contains(url))
-                        retHashSet.Add(url);
+                    if(!dedupeHashSet.Contains(url) && dedupeHashSet.Add(url))
+                        retList.Add(url);
                 }
             }
 
-            return retHashSet.ToList();
+            return retList;
         }
 
         public async Task ProcessCrawledUrl(ICrawledUrl crawledUrl)


### PR DESCRIPTION
Fix AlexCSDev/PatreonDownloader#163

Since the insertion order will be lost during deduplicate support urls, Downloaders will re-download files that are same name but with different sequence number in random.

This commit should fix this, but we may also check the related plugins to make sure the plugins also keep this order when it return supported urls.

But since the sequence numbers are determined when downloading and the downloader support multi-thread download, which will also slightly caused random re-download. 

We may find a solution to make this right, and I will create another issue about this.