### PR TITLE
Update PuppeteerSharp to 19.0.1 (Chrome 127.0.6533.88)

### DIFF
--- a/UniversalDownloaderPlatform.PuppeteerEngine/Interfaces/Wrappers/Browser/IWebPage.cs
+++ b/UniversalDownloaderPlatform.PuppeteerEngine/Interfaces/Wrappers/Browser/IWebPage.cs
@@ -14,7 +14,7 @@ namespace UniversalDownloaderPlatform.PuppeteerEngine.Interfaces.Wrappers.Browse
         Task<IWebResponse> GoToAsync(string url, int? timeout = null, WaitUntilNavigation[] waitUntil = null);
         Task SetUserAgentAsync(string userAgent);
         Task<string> GetContentAsync();
-        Task<IWebRequest> WaitForRequestAsync(Func<Request, bool> predicate, WaitForOptions options = null);
+        Task<IWebRequest> WaitForRequestAsync(Func<IRequest, bool> predicate, WaitForOptions options = null);
         Task<CookieParam[]> GetCookiesAsync(params string[] urls);
         Task CloseAsync(PageCloseOptions options = null);
     }

--- a/UniversalDownloaderPlatform.PuppeteerEngine/PuppeteerEngine.cs
+++ b/UniversalDownloaderPlatform.PuppeteerEngine/PuppeteerEngine.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -17,7 +17,7 @@ namespace UniversalDownloaderPlatform.PuppeteerEngine
 {
     internal class PuppeteerEngine : IPuppeteerEngine, IDisposable
     {
-        private Browser _browser;
+        private IBrowser _browser;
         private IWebBrowser _browserWrapper;
 
         private bool _headless;
@@ -132,7 +132,7 @@ namespace UniversalDownloaderPlatform.PuppeteerEngine
             try
             {
                 _logger.Debug("Downloading browser");
-                await new BrowserFetcher().DownloadAsync(BrowserFetcher.DefaultRevision);
+                await new BrowserFetcher().DownloadAsync();
                 _logger.Debug("Launching browser");
 
                 List<string> browserArguments = new List<string>();
@@ -154,7 +154,7 @@ namespace UniversalDownloaderPlatform.PuppeteerEngine
                 });
 
                 _logger.Debug("Opening new page");
-                Page descriptionPage = await _browser.NewPageAsync();
+                IPage descriptionPage = await _browser.NewPageAsync();
                 await descriptionPage.SetContentAsync("<h1>This is a browser of universal downloader platform</h1>");
 
                 _logger.Debug("Creating IWebBrowser");
@@ -184,7 +184,7 @@ namespace UniversalDownloaderPlatform.PuppeteerEngine
                 });
 
                 _logger.Debug("Opening new page");
-                Page descriptionPage = await _browser.NewPageAsync();
+                IPage descriptionPage = await _browser.NewPageAsync();
                 await descriptionPage.SetContentAsync("<h1>This is a browser of universal downloader platform</h1>");
 
                 _logger.Debug("Creating IWebBrowser");

--- a/UniversalDownloaderPlatform.PuppeteerEngine/UniversalDownloaderPlatform.PuppeteerEngine.csproj
+++ b/UniversalDownloaderPlatform.PuppeteerEngine/UniversalDownloaderPlatform.PuppeteerEngine.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Ninject" Version="3.3.6" />
     <PackageReference Include="ninject.extensions.conventions" Version="3.3.0" />
     <PackageReference Include="NLog" Version="5.0.0" />
-    <PackageReference Include="PuppeteerSharp" Version="6.2.0" />
+    <PackageReference Include="PuppeteerSharp" Version="19.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UniversalDownloaderPlatform.PuppeteerEngine/Wrappers/Browser/WebBrowser.cs
+++ b/UniversalDownloaderPlatform.PuppeteerEngine/Wrappers/Browser/WebBrowser.cs
@@ -10,9 +10,9 @@ namespace UniversalDownloaderPlatform.PuppeteerEngine.Wrappers.Browser
     /// </summary>
     public sealed class WebBrowser : IWebBrowser
     {
-        private readonly PuppeteerSharp.Browser _browser;
+        private readonly PuppeteerSharp.IBrowser _browser;
 
-        public WebBrowser(PuppeteerSharp.Browser browser)
+        public WebBrowser(PuppeteerSharp.IBrowser browser)
         {
             _browser = browser ?? throw new ArgumentNullException(nameof(browser));
         }

--- a/UniversalDownloaderPlatform.PuppeteerEngine/Wrappers/Browser/WebPage.cs
+++ b/UniversalDownloaderPlatform.PuppeteerEngine/Wrappers/Browser/WebPage.cs
@@ -12,9 +12,9 @@ namespace UniversalDownloaderPlatform.PuppeteerEngine.Wrappers.Browser
     /// </summary>
     public sealed class WebPage : IWebPage
     {
-        private readonly Page _page;
+        private readonly IPage _page;
         private bool _configured;
-        public WebPage(Page page)
+        public WebPage(IPage page)
         {
             _page = page ?? throw new ArgumentNullException(nameof(page));
             _configured = false;
@@ -32,7 +32,7 @@ namespace UniversalDownloaderPlatform.PuppeteerEngine.Wrappers.Browser
             if (!timeout.HasValue)
                 timeout = 60000;
 
-            Response response = await _page.GoToAsync(url, timeout, waitUntil);
+            IResponse response = await _page.GoToAsync(url, timeout, waitUntil);
             IWebResponse webResponse = new WebResponse(response);
             return webResponse;
         }
@@ -47,10 +47,10 @@ namespace UniversalDownloaderPlatform.PuppeteerEngine.Wrappers.Browser
             return await _page.GetContentAsync();
         }
 
-        public async Task<IWebRequest> WaitForRequestAsync(Func<Request, bool> predicate, WaitForOptions options = null)
+        public async Task<IWebRequest> WaitForRequestAsync(Func<IRequest, bool> predicate, WaitForOptions options = null)
         {
             await ConfigurePage();
-            Request request = await _page.WaitForRequestAsync(predicate, options);
+            IRequest request = await _page.WaitForRequestAsync(predicate, options);
             IWebRequest webRequest = new WebRequest(request);
             return webRequest;
         }

--- a/UniversalDownloaderPlatform.PuppeteerEngine/Wrappers/Browser/WebRequest.cs
+++ b/UniversalDownloaderPlatform.PuppeteerEngine/Wrappers/Browser/WebRequest.cs
@@ -10,9 +10,9 @@ namespace UniversalDownloaderPlatform.PuppeteerEngine.Wrappers.Browser
     /// </summary>
     public sealed class WebRequest : IWebRequest
     {
-        private readonly Request _request;
+        private readonly IRequest _request;
 
-        public WebRequest(Request request)
+        public WebRequest(IRequest request)
         {
             _request = request ?? throw new ArgumentNullException(nameof(request));
         }

--- a/UniversalDownloaderPlatform.PuppeteerEngine/Wrappers/Browser/WebResponse.cs
+++ b/UniversalDownloaderPlatform.PuppeteerEngine/Wrappers/Browser/WebResponse.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Threading.Tasks;
 using PuppeteerSharp;
@@ -12,8 +12,8 @@ namespace UniversalDownloaderPlatform.PuppeteerEngine.Wrappers.Browser
     /// </summary>
     public sealed class WebResponse : IWebResponse
     {
-        private readonly Response _response;
-        public WebResponse(Response response)
+        private readonly IResponse _response;
+        public WebResponse(IResponse response)
         {
             _response = response ?? throw new ArgumentNullException(nameof(response));
         }


### PR DESCRIPTION
This PR updates PuppeteerSharp to 19.0.1, which uses the latest (at least for now) Chrome. I believe it somewhat reduced chances of getting blocked by Cloudflare.

Minor changes were made to adopt the new API:
- `Request` -> `IRequest`
- `Response` -> `IResponse`
- `Browser` -> `IBrowser`
- `Page` -> `IPage`

The submodule in PatreonDownloader should be updated accordingly. It's worth noting that [this file](https://github.com/AlexCSDev/PatreonDownloader/blob/master/docs/REMOTEBROWSER.md) should be updated too, since the Chrome is stored in `./Chrome` instead of `./.local-chromium` now.
